### PR TITLE
additional openstack_db_database_v1 fixes

### DIFF
--- a/openstack/import_openstack_db_database_v1_test.go
+++ b/openstack/import_openstack_db_database_v1_test.go
@@ -1,0 +1,28 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDatabaseV1Database_importBasic(t *testing.T) {
+	resourceName := "openstack_db_database_v1.basic"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckDatabase(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabaseV1DatabaseDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDatabaseV1DatabaseBasic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/resource_openstack_db_database_v1_test.go
+++ b/openstack/resource_openstack_db_database_v1_test.go
@@ -2,35 +2,43 @@ package openstack
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/gophercloud/gophercloud/openstack/db/v1/databases"
+	"github.com/gophercloud/gophercloud/openstack/db/v1/instances"
 )
 
 func TestAccDatabaseV1Database_basic(t *testing.T) {
 	var db databases.Database
+	var instance instances.Instance
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckDatabase(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheckDatabase(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabaseV1DatabaseDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDatabaseV1DatabaseBasic,
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseV1InstanceExists(
+						"openstack_db_instance_v1.basic", &instance),
 					testAccCheckDatabaseV1DatabaseExists(
-						"openstack_db_database_v1.basic", &db),
-					resource.TestCheckResourceAttr(
-						"openstack_db_database_v1.basic", "name", "basic"),
+						"openstack_db_database_v1.basic", &instance, &db),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_db_database_v1.basic", "name", &db.Name),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckDatabaseV1DatabaseExists(n string, db *databases.Database) resource.TestCheckFunc {
+func testAccCheckDatabaseV1DatabaseExists(
+	n string, instance *instances.Instance, db *databases.Database) resource.TestCheckFunc {
+
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -41,36 +49,86 @@ func testAccCheckDatabaseV1DatabaseExists(n string, db *databases.Database) reso
 			return fmt.Errorf("No ID is set")
 		}
 
+		parts := strings.SplitN(rs.Primary.ID, "/", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("Malformed database name: %s", rs.Primary.ID)
+		}
+
 		config := testAccProvider.Meta().(*Config)
 		databaseV1Client, err := config.databaseV1Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 		}
 
-		dbInstance := s.RootModule().Resources["openstack_db_instance_v1.basic"]
-
-		pages, err := databases.List(databaseV1Client, dbInstance.Primary.ID).AllPages()
+		pages, err := databases.List(databaseV1Client, instance.ID).AllPages()
 		if err != nil {
-			return fmt.Errorf("Unable to retrieve databases, pages: %s", err)
+			return fmt.Errorf("Unable to retrieve databases: %s", err)
 		}
 
 		allDatabases, err := databases.ExtractDBs(pages)
 		if err != nil {
-			return fmt.Errorf("Unable to retrieve databases, extract: %s", err)
+			return fmt.Errorf("Unable to extract databases: %s", err)
 		}
 
 		for _, v := range allDatabases {
-			if v.Name == db.Name {
+			if v.Name == parts[1] {
+				*db = v
 				return nil
 			}
 		}
-		return nil
+
+		return fmt.Errorf("database %s does not exist", n)
 	}
+}
+
+func testAccCheckDatabaseV1DatabaseDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+
+	databaseV1Client, err := config.databaseV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_db_database_v1" {
+			continue
+		}
+
+		parts := strings.SplitN(rs.Primary.ID, "/", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("Malformed database name: %s", rs.Primary.ID)
+		}
+
+		pages, err := databases.List(databaseV1Client, parts[0]).AllPages()
+		if err != nil {
+			return nil
+		}
+
+		allDatabases, err := databases.ExtractDBs(pages)
+		if err != nil {
+			return fmt.Errorf("Unable to extract databases: %s", err)
+		}
+
+		var exists bool
+		for _, v := range allDatabases {
+			if v.Name == parts[1] {
+				exists = true
+			}
+		}
+
+		if exists {
+			return fmt.Errorf("database still exists")
+		}
+	}
+
+	return nil
 }
 
 var testAccDatabaseV1DatabaseBasic = fmt.Sprintf(`
 resource "openstack_db_instance_v1" "basic" {
   name = "basic"
+  size = 10
+
   datastore {
     version = "%s"
     type    = "%s"
@@ -79,12 +137,10 @@ resource "openstack_db_instance_v1" "basic" {
   network {
     uuid = "%s"
   }
-  size = 10
-
 }
 
 resource "openstack_db_database_v1" "basic" {
-  name     = "basic"
-  instance = "${openstack_db_instance_v1.basic.id}"
+  name        = "basic"
+  instance_id = "${openstack_db_instance_v1.basic.id}"
 }
 `, OS_DB_DATASTORE_VERSION, OS_DB_DATASTORE_TYPE, OS_NETWORK_ID)

--- a/website/docs/r/db_database_v1.html.markdown
+++ b/website/docs/r/db_database_v1.html.markdown
@@ -15,9 +15,9 @@ Manages a V1 DB database resource within OpenStack.
 ### Database
 
 ```hcl
-resource "openstack_db_database_v1" "test" {
-  name     = "testdb"
-  instance = "${openstack_db_instance_v1.basic.id}"
+resource "openstack_db_database_v1" "mydb" {
+  name        = "mydb"
+  instance_id = "${openstack_db_instance_v1.basic.id}"
 }
 ```
 
@@ -27,7 +27,7 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource.
 
-* `instance` - (Required) The ID for the database instance.
+* `instance_id` - (Required) The ID for the database instance.
 
 ## Attributes Reference
 
@@ -35,4 +35,12 @@ The following attributes are exported:
 
 * `region` - Openstack region resource is created in.
 * `name` - See Argument Reference above.
-* `instance` - See Argument Reference above.
+* `instance_id` - See Argument Reference above.
+
+## Import
+
+Databases can be imported by using `instance-id/db-name`, e.g.
+
+```
+$ terraform import openstack_db_database_v1.mydb 7b9e3cd3-00d9-449c-b074-8439f8e274fa/mydb
+```


### PR DESCRIPTION
@eugenetaranov Here are some fixes for the `openstack_db_database_v1` resource.

The reason the database was not being stored in state was because the instance's Read function was being called. 

Additionally, I switched to using `/` as a separator rather than `.`. We use `/` throughout Terraform so it shouldn't caue any problems.

Once this is merged, it will automatically be reflected at github.com/terraform-provider/terraform-provider-openstack. Please let me know if you have any questions.